### PR TITLE
feat: enhance authentication security and add centralized error handling

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,6 +1,7 @@
 import os
 
-from flask import Flask
+from flask import Flask, jsonify
+from werkzeug.exceptions import HTTPException
 
 from backend.config import Config
 from backend.extensions import cors, db, jwt, migrate
@@ -18,6 +19,27 @@ def create_app(config_class: Config):
     migrations_dir = os.path.join(app.root_path, "migrations")
     migrate.init_app(app, db, directory=migrations_dir)
     cors.init_app(app)
+
+    # Register centralized error handlers
+    @app.errorhandler(Exception)
+    def handle_exception(e):
+        """Handle all unhandled exceptions with consistent JSON response."""
+        # Pass through HTTP exceptions
+        if isinstance(e, HTTPException):
+            return jsonify(error=str(e.description)), e.code
+        # Handle non-HTTP exceptions
+        app.logger.error(f"Unhandled exception: {str(e)}", exc_info=True)
+        return jsonify(error="An unexpected error occurred. See server logs for details."), 500
+
+    @app.errorhandler(404)
+    def resource_not_found(e):
+        """Handle 404 errors with consistent JSON response."""
+        return jsonify(error="Resource not found"), 404
+
+    @app.errorhandler(400)
+    def bad_request(e):
+        """Handle 400 errors with consistent JSON response."""
+        return jsonify(error=str(e.description)), 400
 
     # Import blueprints
     from backend.routes import api_bp, base_bp


### PR DESCRIPTION
- Set access tokens as cookies instead of URL parameters for better security
- Add /api/users/me endpoint for fetching current user data
- Implement centralized error handlers for consistent JSON responses
- Redirect OAuth callback to clean URL without tokens

This addresses security concerns with tokens in browser history/logs and provides better error handling consistency across the API.